### PR TITLE
per2axi_req_channel: Fix handshake on `per_slave` port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fix handshake on `per_slave` port that could cause transactions to be lost if the downstream AW
+  channel was ready but the W channel was not.
 
 ## 1.0.2 - 2018-09-12
 ### Changed

--- a/src/per2axi_req_channel.sv
+++ b/src/per2axi_req_channel.sv
@@ -143,7 +143,7 @@ module per2axi_req_channel
      end
    
    // PERIPHERAL INTERCONNECT GRANT GENERATION
-   assign per_slave_gnt_o = axi_master_aw_ready_i && axi_master_ar_ready_i;
+   assign per_slave_gnt_o = axi_master_aw_ready_i && axi_master_ar_ready_i && axi_master_w_ready_i;
    
    always_comb
      begin


### PR DESCRIPTION
Fix handshake on `per_slave` port that could cause transactions to be lost if the downstream AW  channel was ready but the W channel was not.